### PR TITLE
Load PHPCR fixtures

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -103,6 +103,11 @@ class MyTest extends WebTestCase
   Load fixtures simply with `$this->loadFixtures(['YourFixtureClassName', 'YourOtherFixtureClassName'])`. Dependencies
   are resolved (as long as you implement `DependentFixtureInterface`), so you don't need to explicitly load all your fixtures.
 
+* PHPCR fixtures load
+
+  Load fixtures simply with `$this->loadPhpcrFixtures(['YourFixtureClassName', 'YourOtherFixtureClassName'])`. Dependencies
+  are resolved (as long as you implement `DependentFixtureInterface`), so you don't need to explicitly load all your fixtures.
+
 * Mail sent assertion
 
   Check how many mails has been sent with ``$this->assertMailSent(1)`` (or 2, 3, etc.). You need to call


### PR DESCRIPTION
~~Merge after https://github.com/Bee-Lab/BeelabTestBundle/pull/6, else you have to use two different `Loader`s for ORM and PHPCR.~~
Writing my tests using `loadPhpcrFixtures` I see that this PR is **not** related with https://github.com/Bee-Lab/BeelabTestBundle/pull/6