### PR TITLE
Allow to use loadFixtures more than once

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -204,7 +204,7 @@ EOF;
      * @param string $namespace
      * @param string $manager
      */
-    protected function loadFixtures(array $fixtures, $namespace = 'AppBundle\\DataFixtures\\ORM\\', $manager = null)
+    protected function loadFixtures(array $fixtures, $namespace = 'AppBundle\\DataFixtures\\ORM\\', $manager = null, $append = false)
     {
         $this->em->getConnection()->exec('SET foreign_key_checks = 0');
         $loader = new Loader($this->container);
@@ -213,7 +213,7 @@ EOF;
         }
         $manager = is_null($manager) ? $this->em : $this->container->get($manager);
         $executor = new ORMExecutor($manager, new ORMPurger());
-        $executor->execute($loader->getFixtures());
+        $executor->execute($loader->getFixtures(), $append);
         $this->em->getConnection()->exec('SET foreign_key_checks = 1');
     }
 


### PR DESCRIPTION
This PR Allows to use `loadFixtures` more than one time consecutively.

**My use case:**
I've an admin area with many different sub-sections, I want to load users fixtures and login the user and then continue testing the sub-sections.

```php
abstract class AdminAreaController extends WebTestCase
{
    public function setUp()
    {
        parent::setUp();

        $this->loadFixtures(['loadUsers'];
        $this->login('testuser', 'admin_login_area', 'speeddate.repository.operator');
    }
}

class SectionAControllerTest extends AdminAreaController
{
    public function testList()
    {
        $this->loadFixtures(['EntityA']);
        $this->page = $this->client->request('GET', '/admin/a/');
        $this->assertTrue($this->client->getResponse()->isOk());
    }

    public function testShow()
    {
        // ...
    }

    public function testEdit()
    {
        // ...
    }
}

class SectionBControllerTest extends AdminAreaController
{
    public function testList()
    {
        $this->loadFixtures(['EntityB']);
        $this->page = $this->client->request('GET', '/admin/b/');
        $this->assertTrue($this->client->getResponse()->isOk());
    }

    public function testShow()
    {
        // ...
    }

    public function testEdit()
    {
        // ...
    }
}

// Other admin sections
```