### PR TITLE
Drop references to Symfony 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ This bundle contains just an opinionated extension of Symfony `WebTestCase`.
 Documentation
 -------------
 
->**WARNING** if you're using version 3 of this bundle with Symfony 4.2, and you want to upgrade to
->Symfony 4.3, you need to require version 4 of this bundle. See also [UPGRADE file](UPGRADE.md).
->If you use Symfony 6.0, you need to pay attention to definition of service, as explained in following documentation.
+If you use Symfony 6.0, you need to pay attention to definition of service, as explained in following documentation.
 
 [Read the documentation](docs/index.md)
 


### PR DESCRIPTION
It's no longer supported in composer.json, so it's not necessary in the most recent branches.